### PR TITLE
path of PCK file when generating SimulatorDS

### DIFF
--- a/doc/gen_simulation.rst
+++ b/doc/gen_simulation.rst
@@ -43,6 +43,8 @@ or directly parse the source files for hardcoded device names.
 Generate simulators in your test environment
 --------------------------------------------
 
+In the following, PCK file has to be in the **current** directory to work.
+
 ::
 
   cd /home/user/test #Or wherever


### PR DESCRIPTION
warning about the place of PCK file which should be in the current directory.